### PR TITLE
feat(listeners): wire OtherDeviceLogout to its dedicated event and listener config keys

### DIFF
--- a/src/LaravelAuthLogsServiceProvider.php
+++ b/src/LaravelAuthLogsServiceProvider.php
@@ -92,7 +92,9 @@ final class LaravelAuthLogsServiceProvider extends PackageServiceProvider
     }
 
     /**
-     * @param  Dispatcher  $event
+     * Subscribe to the other device logout event to log when a user revokes other active sessions.
+     *
+     * @param  Dispatcher  $event  The event dispatcher instance.
      */
     private function subscribeToLogoutOtherDeviceEvent(Dispatcher $event): void
     {

--- a/src/LaravelAuthLogsServiceProvider.php
+++ b/src/LaravelAuthLogsServiceProvider.php
@@ -92,17 +92,14 @@ final class LaravelAuthLogsServiceProvider extends PackageServiceProvider
     }
 
     /**
-     * Subscribe to the "logout other devices" event to log when a user logs out
-     * from other active sessions on different devices.
-     *
-     * @param  Dispatcher  $event  The event dispatcher instance.
+     * @param  Dispatcher  $event
      */
     private function subscribeToLogoutOtherDeviceEvent(Dispatcher $event): void
     {
 
         $event->listen(
-            events  : config('auth-logs.events.logout', OtherDeviceLogout::class),
-            listener: config('auth-logs.listeners.logout', OtherDeviceLogoutListener::class),
+            events  : config('auth-logs.events.logout-other-devices', OtherDeviceLogout::class),
+            listener: config('auth-logs.listeners.other_device_logout', OtherDeviceLogoutListener::class),
         );
     }
 }

--- a/tests/Unit/ListenersTest.php
+++ b/tests/Unit/ListenersTest.php
@@ -6,9 +6,13 @@ use Akira\LaravelAuthLogs\Actions\CreateAuthenticationLog;
 use Akira\LaravelAuthLogs\AuthenticationLog;
 use Akira\LaravelAuthLogs\Listeners\FailedLoginListener;
 use Akira\LaravelAuthLogs\Listeners\LoginListener;
+use Akira\LaravelAuthLogs\Listeners\LogoutListener;
+use Akira\LaravelAuthLogs\Listeners\OtherDeviceLogoutListener;
 use Akira\LaravelAuthLogs\Tests\Fixtures\User;
 use Illuminate\Auth\Events\Failed;
 use Illuminate\Auth\Events\Login;
+use Illuminate\Auth\Events\Logout;
+use Illuminate\Auth\Events\OtherDeviceLogout;
 use Illuminate\Support\Facades\Notification;
 
 it('login listener logs and conditionally notifies', function (): void {
@@ -39,5 +43,21 @@ it('failed login listener logs for user', function (): void {
     new FailedLoginListener()->handle(new Failed('web', $user, []));
 
     expect(AuthenticationLog::query()->count())->toBe(1);
+});
+
+it('logout event is registered to LogoutListener independently', function (): void {
+    $raw = app('events')->getRawListeners();
+
+    expect($raw)->toHaveKey(Logout::class)
+        ->and($raw[Logout::class])->toContain(LogoutListener::class)
+        ->and($raw[Logout::class])->not->toContain(OtherDeviceLogoutListener::class);
+});
+
+it('other device logout event is registered to OtherDeviceLogoutListener independently', function (): void {
+    $raw = app('events')->getRawListeners();
+
+    expect($raw)->toHaveKey(OtherDeviceLogout::class)
+        ->and($raw[OtherDeviceLogout::class])->toContain(OtherDeviceLogoutListener::class)
+        ->and($raw[OtherDeviceLogout::class])->not->toContain(LogoutListener::class);
 });
 


### PR DESCRIPTION
## Summary

- Corrects the config key lookup for the `OtherDeviceLogout` event binding from the shared `events.logout` / `listeners.logout` keys to dedicated `events.logout-other-devices` / `listeners.other_device_logout` keys, matching what is already defined in `config/auth-logs.php`
- Adds two new tests asserting that `Logout` and `OtherDeviceLogout` are each wired exclusively to their own listener, with no cross-registration

## Test plan

- [ ] `it logout event is registered to LogoutListener independently` passes
- [ ] `it other device logout event is registered to OtherDeviceLogoutListener independently` passes
- [ ] All 31 existing tests pass
- [ ] Pint, Rector, and PHPStan report no violations