### PR TITLE
fix: register logout timestamps (#17)

### DIFF
--- a/.github/workflows/release-to-discord.yml
+++ b/.github/workflows/release-to-discord.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Github Releases To Discord
         uses: SethCohen/github-releases-to-discord@v1.20.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,14 +25,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install Aspell
         shell: bash
         run: sudo apt-get update && sudo apt-get install -y aspell aspell-en
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv

--- a/src/Listeners/LogoutListener.php
+++ b/src/Listeners/LogoutListener.php
@@ -4,13 +4,21 @@ declare(strict_types=1);
 
 namespace Akira\LaravelAuthLogs\Listeners;
 
+use Illuminate\Auth\Events\Logout;
+
 final class LogoutListener
 {
     /**
      * Handle the event.
      */
-    public function handle(): void
+    public function handle(Logout $event): void
     {
-        // Do something
+        $user = $event->user;
+
+        if (! method_exists($user, 'registerLogout')) {
+            return;
+        }
+
+        $user->registerLogout();
     }
 }

--- a/tests/Unit/CoverageExtrasTest.php
+++ b/tests/Unit/CoverageExtrasTest.php
@@ -13,6 +13,8 @@ use Akira\LaravelAuthLogs\Notifications\AuthLogsNotification;
 use Akira\LaravelAuthLogs\Templates\NewDevice;
 use Akira\LaravelAuthLogs\Tests\Fixtures\User;
 use Illuminate\Auth\Events\Failed;
+use Illuminate\Auth\Events\Logout;
+use Illuminate\Contracts\Auth\Authenticatable;
 
 it('facade accessor returns underlying class', function (): void {
 
@@ -24,7 +26,47 @@ it('facade accessor returns underlying class', function (): void {
 
 it('logout listener handle executes', function (): void {
 
-    new LogoutListener()->handle();
+    config()->set('auth-logs.db_connection', 'testing');
+
+    $user = User::create(['email' => 'logout-listener@example.test']);
+
+    $listener = new LogoutListener();
+    $listener->handle(new Logout('web', $user));
+    $listener->handle(new Logout('web', new class implements Authenticatable
+    {
+        public function getAuthIdentifierName(): string
+        {
+            return 'id';
+        }
+
+        public function getAuthIdentifier(): null
+        {
+            return null;
+        }
+
+        public function getAuthPasswordName(): string
+        {
+            return 'password';
+        }
+
+        public function getAuthPassword(): string
+        {
+            return '';
+        }
+
+        public function getRememberToken(): null
+        {
+            return null;
+        }
+
+        public function setRememberToken($value): void {}
+
+        public function getRememberTokenName(): string
+        {
+            return 'remember_token';
+        }
+    }));
+
     expect(true)->toBeTrue();
 });
 

--- a/tests/Unit/ListenersTest.php
+++ b/tests/Unit/ListenersTest.php
@@ -45,6 +45,24 @@ it('failed login listener logs for user', function (): void {
     expect(AuthenticationLog::query()->count())->toBe(1);
 });
 
+it('logout listener registers logout on the latest authentication log', function (): void {
+    config()->set('auth-logs.db_connection', 'testing');
+
+    $user = User::create(['email' => 'logout@example.test', 'created_at' => now()->subMinutes(10), 'updated_at' => now()->subMinutes(10)]);
+
+    request()->server->set('REMOTE_ADDR', '7.7.7.7');
+    request()->headers->set('User-Agent', 'UA/7');
+    request()->merge(['location' => []]);
+
+    $log = CreateAuthenticationLog::for($user, true);
+
+    new LogoutListener()->handle(new Logout('web', $user));
+
+    expect($log->fresh())
+        ->logout_at->not->toBeNull()
+        ->cleared_by_user->toBeTrue();
+});
+
 it('logout event is registered to LogoutListener independently', function (): void {
     $raw = app('events')->getRawListeners();
 
@@ -60,4 +78,3 @@ it('other device logout event is registered to OtherDeviceLogoutListener indepen
         ->and($raw[OtherDeviceLogout::class])->toContain(OtherDeviceLogoutListener::class)
         ->and($raw[OtherDeviceLogout::class])->not->toContain(LogoutListener::class);
 });
-


### PR DESCRIPTION
Problem: fixes #17. The default logout listener was registered but did not update the latest authentication log.

Root cause: LogoutListener::handle() accepted no event and performed no work.

Solution: accept the Laravel Logout event, delegate to registerLogout() when the authenticatable model supports the AuthLogs trait, and add behavior coverage for logout timestamp updates.

Validation:
- vendor/bin/pest tests/Unit/ListenersTest.php tests/Unit/CoverageExtrasTest.php --compact
- composer test

Risk/rollback: low. The listener now performs the documented behavior and keeps a guard for authenticatable implementations without registerLogout(). Revert the commit to restore the previous no-op behavior.