### PR TITLE
fix: honor auth notification flags (#18)

### DIFF
--- a/src/Listeners/FailedLoginListener.php
+++ b/src/Listeners/FailedLoginListener.php
@@ -29,6 +29,10 @@ final class FailedLoginListener
 
         $log = CreateAuthenticationLog::for($user);
 
+        if (! (bool) config('auth-logs.templates.failed_login.notification', true)) {
+            return;
+        }
+
         SendNotification::make(authenticatable: $user, template: $template, log: $log)->send();
     }
 }

--- a/src/Listeners/LoginListener.php
+++ b/src/Listeners/LoginListener.php
@@ -29,8 +29,10 @@ final class LoginListener
 
         $log = CreateAuthenticationLog::for($user, isSuccessFull: true);
 
+        $shouldSendNotification = (bool) config('auth-logs.templates.new_device.notification', true);
+
         // @phpstan-ignore-next-line
-        if (! $isKnown instanceof AuthenticationLog && ! $user->isNew()) {
+        if ($shouldSendNotification && ! $isKnown instanceof AuthenticationLog && ! $user->isNew()) {
             SendNotification::make(authenticatable: $user, template: $template, log: $log)->send();
         }
     }

--- a/tests/Unit/ListenersTest.php
+++ b/tests/Unit/ListenersTest.php
@@ -30,6 +30,23 @@ it('login listener logs and conditionally notifies', function (): void {
     expect(AuthenticationLog::query()->count())->toBe(1);
 });
 
+it('login listener respects disabled new device notifications', function (): void {
+    config()->set('auth-logs.db_connection', 'testing');
+    config()->set('auth-logs.templates.new_device.notification', false);
+    Notification::fake();
+
+    $user = User::create(['email' => 'disabled-login@example.test', 'created_at' => now()->subMinutes(10), 'updated_at' => now()->subMinutes(10)]);
+
+    request()->server->set('REMOTE_ADDR', '5.5.5.6');
+    request()->headers->set('User-Agent', 'UA/5-disabled');
+    request()->merge(['location' => []]);
+
+    new LoginListener()->handle(new Login('web', $user, false));
+
+    expect(AuthenticationLog::query()->count())->toBe(1);
+    Notification::assertNothingSent();
+});
+
 it('failed login listener logs for user', function (): void {
     config()->set('auth-logs.db_connection', 'testing');
     Notification::fake();
@@ -43,6 +60,23 @@ it('failed login listener logs for user', function (): void {
     new FailedLoginListener()->handle(new Failed('web', $user, []));
 
     expect(AuthenticationLog::query()->count())->toBe(1);
+});
+
+it('failed login listener respects disabled notifications', function (): void {
+    config()->set('auth-logs.db_connection', 'testing');
+    config()->set('auth-logs.templates.failed_login.notification', false);
+    Notification::fake();
+
+    $user = User::create(['email' => 'disabled-failed@example.test', 'created_at' => now()->subMinutes(10), 'updated_at' => now()->subMinutes(10)]);
+
+    request()->server->set('REMOTE_ADDR', '6.6.6.7');
+    request()->headers->set('User-Agent', 'UA/6-disabled');
+    request()->merge(['location' => []]);
+
+    new FailedLoginListener()->handle(new Failed('web', $user, []));
+
+    expect(AuthenticationLog::query()->count())->toBe(1);
+    Notification::assertNothingSent();
 });
 
 it('logout listener registers logout on the latest authentication log', function (): void {


### PR DESCRIPTION
Problem: fixes #18. The package exposed notification enable flags, but listeners ignored them.

Root cause: LoginListener and FailedLoginListener only read template classes before sending notifications.

Solution: keep creating authentication logs, but check the configured notification flag before sending new-device or failed-login notifications.

Validation:
- vendor/bin/pest tests/Unit/ListenersTest.php --compact
- composer test

Risk/rollback: low. The default config remains enabled, so existing default behavior is preserved. Revert the commit to restore unconditional notification sending.