### PR TITLE
fix: persist resolved geolocation data (#19)

### DIFF
--- a/.github/workflows/release-to-discord.yml
+++ b/.github/workflows/release-to-discord.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Github Releases To Discord
         uses: SethCohen/github-releases-to-discord@v1.20.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,14 +25,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install Aspell
         shell: bash
         run: sudo apt-get update && sudo apt-get install -y aspell aspell-en
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv

--- a/src/Concerns/InteractsWithLogs.php
+++ b/src/Concerns/InteractsWithLogs.php
@@ -6,6 +6,7 @@ namespace Akira\LaravelAuthLogs\Concerns;
 
 use Akira\LaravelAuthLogs\Actions\GetLocation;
 use Akira\LaravelAuthLogs\ValueObjects\Location;
+use Illuminate\Support\Collection;
 
 trait InteractsWithLogs
 {
@@ -48,13 +49,34 @@ trait InteractsWithLogs
     public function getFullLocation(): string
     {
 
-        $location = GetLocation::make($this->getIpAddress());
+        $location = $this->getStoredLocation();
+
+        if ($location->isEmpty()) {
+            $location = GetLocation::make($this->getIpAddress());
+        }
 
         if ($location->isEmpty()) {
             return __('Unknown');
         }
 
+        $this->log->update(['location' => $location->all()]);
+
         return Location::make($location)
             ->getFullLocation();
+    }
+
+    /**
+     * @return Collection<string, mixed>
+     */
+    private function getStoredLocation(): Collection
+    {
+
+        $location = collect($this->log->location ?? []);
+
+        if ($location->has('city') || $location->has('country')) {
+            return $location;
+        }
+
+        return collect();
     }
 }

--- a/tests/Unit/ActionsTest.php
+++ b/tests/Unit/ActionsTest.php
@@ -87,11 +87,33 @@ it('gets location data from local fixture and builds notification', function ():
     expect($sender->getIpAddress())->toBe('1.1.1.1')
         ->and($sender->getUserAgent())->toBe('UA/1.0')
         ->and($sender->getFullLocation())->toBe('Emerald City, Wonderland')
-        ->and($sender->getLoginAt())->toBeString();
+        ->and($sender->getLoginAt())->toBeString()
+        ->and($log->fresh()->location)->toHaveKey('city', 'Emerald City');
 
     $sender->send();
 
     Notification::assertSentTo($user, AuthLogsNotification::class);
+});
+
+it('uses a stored resolved location without another lookup', function (): void {
+    config()->set('auth-logs.db_connection', 'testing');
+    config()->set('auth-logs.geolocation_api', 'php://temp');
+
+    $user = User::create([
+        'email' => 'stored-location@example.test',
+        'created_at' => now()->subMinutes(10),
+        'updated_at' => now()->subMinutes(10),
+    ]);
+
+    request()->server->set('REMOTE_ADDR', '1.1.1.2');
+    request()->headers->set('User-Agent', 'UA/stored');
+    request()->merge(['location' => ['city' => 'Porto', 'country' => 'Portugal']]);
+
+    $log = CreateAuthenticationLog::for($user, true);
+
+    $sender = SendNotification::make($user, NewDevice::class, $log);
+
+    expect($sender->getFullLocation())->toBe('Porto, Portugal');
 });
 
 it('returns empty collection when geolocation fails', function (): void {


### PR DESCRIPTION
Problem: fixes #19. Notifications resolved location text without persisting the resolved geolocation back to the authentication log.

Root cause: InteractsWithLogs always called GetLocation for display and ignored whether the log already had useful location data.

Solution: reuse stored city/country data when present, resolve missing location data for notifications, and persist successful lookup results on the log.

Validation:
- vendor/bin/pest tests/Unit/ActionsTest.php --compact
- composer test

Risk/rollback: medium-low. This adds a write when location is successfully resolved during notification formatting. Revert the commit to restore display-only lookup behavior.