### PR TITLE
fix: allow disabled geolocation (#20)

### DIFF
--- a/.github/workflows/release-to-discord.yml
+++ b/.github/workflows/release-to-discord.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Github Releases To Discord
         uses: SethCohen/github-releases-to-discord@v1.20.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,14 +25,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install Aspell
         shell: bash
         run: sudo apt-get update && sudo apt-get install -y aspell aspell-en
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv

--- a/src/Actions/GetLocation.php
+++ b/src/Actions/GetLocation.php
@@ -21,7 +21,12 @@ final class GetLocation
     public static function make(string $ip): Collection
     {
 
-        $apiBase = type(config('auth-logs.geolocation_api'))->asString();
+        $apiBase = config('auth-logs.geolocation_api');
+
+        if (! is_string($apiBase) || $apiBase === '') {
+            return collect(self::EMPTY_COLLECTION);
+        }
+
         $scheme = self::schemeFrom($apiBase);
 
         if ($scheme === 'file') {
@@ -39,7 +44,7 @@ final class GetLocation
         // produce a single return to make paths explicit and testable.
         $decoded = null;
 
-        if (str_starts_with(type(config('auth-logs.geolocation_api'))->asString(), 'file://')) {
+        if (str_starts_with($apiBase, 'file://')) {
             $decoded = $data ?? (object) self::EMPTY_COLLECTION;
         } else {
             // @phpstan-ignore-next-line

--- a/tests/Unit/ActionsTest.php
+++ b/tests/Unit/ActionsTest.php
@@ -15,7 +15,6 @@ use Illuminate\Support\Facades\Notification;
 it('creates an authentication log via action', function (): void {
     config()->set('auth-logs.db_connection', 'testing');
 
-    // Fake the request context values
     request()->server->set('REMOTE_ADDR', '1.1.1.1');
     request()->headers->set('User-Agent', 'Agent/1.0');
     request()->merge(['location' => ['iso_code' => 'WW']]);
@@ -44,7 +43,6 @@ it('detects known device for user', function (): void {
         'updated_at' => now()->subMinutes(10),
     ]);
 
-    // Seed a successful login for the same ip/ua
     request()->server->set('REMOTE_ADDR', '2.2.2.2');
     request()->headers->set('User-Agent', 'UA/2.0');
     request()->merge(['location' => ['iso_code' => 'WW']]);
@@ -57,7 +55,6 @@ it('detects known device for user', function (): void {
 
 it('gets location data from local fixture and builds notification', function (): void {
     config()->set('auth-logs.db_connection', 'testing');
-    // Point geolocation to local fixture via file:// URL (case-safe)
     $fixtures = realpath(__DIR__.'/../Fixtures') ?: realpath(__DIR__.'/../fixtures');
     config()->set('auth-logs.geolocation_api', 'file://'.$fixtures);
 
@@ -69,21 +66,14 @@ it('gets location data from local fixture and builds notification', function ():
         'updated_at' => now()->subMinutes(10),
     ]);
 
-    // Make a log with ip that matches fixture file name
     request()->server->set('REMOTE_ADDR', '1.1.1.1');
     request()->headers->set('User-Agent', 'UA/1.0');
     request()->merge(['location' => ['status' => 'success']]);
 
-    // Ensure the location helper sees and formats the city/country correctly
-    // by priming a minimal expected shape.
-    // The InteractsWithLogs->getFullLocation() ignores request()->location and
-    // calls GetLocation::make using the configured file fixture. No change
-    // here is necessary beyond ensuring the config points at the file path.
     $log = CreateAuthenticationLog::for($user, true);
 
     $sender = SendNotification::make($user, NewDevice::class, $log);
 
-    // also hit trait helpers directly for coverage
     expect($sender->getIpAddress())->toBe('1.1.1.1')
         ->and($sender->getUserAgent())->toBe('UA/1.0')
         ->and($sender->getFullLocation())->toBe('Emerald City, Wonderland')
@@ -103,11 +93,17 @@ it('returns empty collection when geolocation fails', function (): void {
 });
 
 it('returns empty collection when geolocation is disabled', function (): void {
-    config()->set('auth-logs.geolocation_api');
+    $geolocationApi = config('auth-logs.geolocation_api');
 
-    $result = GetLocation::make('9.9.9.9');
+    try {
+        config(['auth-logs.geolocation_api' => null]);
 
-    expect($result->isEmpty())->toBeTrue();
+        $result = GetLocation::make('9.9.9.9');
+
+        expect($result->isEmpty())->toBeTrue();
+    } finally {
+        config(['auth-logs.geolocation_api' => $geolocationApi]);
+    }
 });
 
 it('validates send notification properties', function (): void {
@@ -118,7 +114,6 @@ it('validates send notification properties', function (): void {
     request()->merge(['location' => []]);
     $log = CreateAuthenticationLog::for($user, false);
 
-    // Invalid template string should throw (template check)
     $ref = new \ReflectionClass(SendNotification::class);
     $ctor = $ref->getConstructor();
     $instance = $ref->newInstanceWithoutConstructor();
@@ -129,13 +124,11 @@ it('validates send notification properties', function (): void {
     expect(fn (): mixed => $method->invoke($instance))
         ->toThrow(RuntimeException::class);
 
-    // Missing authenticatable should throw (first guard)
     $noAuth = $ref->newInstanceWithoutConstructor();
     $sendNoAuth = new \ReflectionMethod($noAuth, 'send');
     expect(fn (): mixed => $sendNoAuth->invoke($noAuth))
         ->toThrow(RuntimeException::class);
 
-    // Missing log should throw (last guard)
     $missingLog = $ref->newInstanceWithoutConstructor();
     $pa = new \ReflectionProperty(SendNotification::class, 'authenticatable');
     $pt = new \ReflectionProperty(SendNotification::class, 'template');

--- a/tests/Unit/ActionsTest.php
+++ b/tests/Unit/ActionsTest.php
@@ -102,6 +102,14 @@ it('returns empty collection when geolocation fails', function (): void {
     expect($result->isEmpty())->toBeTrue();
 });
 
+it('returns empty collection when geolocation is disabled', function (): void {
+    config()->set('auth-logs.geolocation_api');
+
+    $result = GetLocation::make('9.9.9.9');
+
+    expect($result->isEmpty())->toBeTrue();
+});
+
 it('validates send notification properties', function (): void {
     config()->set('auth-logs.db_connection', 'testing');
     $user = User::create(['email' => 'err@example.test']);


### PR DESCRIPTION
Problem: fixes #20. Setting geolocation_api to null was documented but could still flow into string-only handling.

Root cause: GetLocation forced the configured endpoint through asString() before checking whether geolocation was disabled.

Solution: treat non-string and empty endpoint values as disabled geolocation and return an empty collection without opening streams.

Validation:
- vendor/bin/pest tests/Unit/ActionsTest.php tests/Unit/CoverageExtrasTest.php --compact
- composer test

Risk/rollback: low. Valid string endpoints keep the existing behavior. Revert the commit to restore strict string endpoint handling.