### PR TITLE
fix: reject unsupported notification channels (#21)

### DIFF
--- a/.github/workflows/release-to-discord.yml
+++ b/.github/workflows/release-to-discord.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Github Releases To Discord
         uses: SethCohen/github-releases-to-discord@v1.20.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,14 +25,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install Aspell
         shell: bash
         run: sudo apt-get update && sudo apt-get install -y aspell aspell-en
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv

--- a/config/auth-logs.php
+++ b/config/auth-logs.php
@@ -64,8 +64,8 @@ return [
     | Notification Channels
     |--------------------------------------------------------------------------
     |
-    | Define the notification channels for authentication events. The default
-    | channel is 'mail'. Add other channels such as 'slack' or 'nexmo' if required.
+    | Define the notification channels for authentication events. The built-in
+    | notification supports the 'mail' channel.
     |
     */
     'notification_via' => ['mail'],

--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -50,11 +50,7 @@ Define how authentication notifications are delivered:
 'notification_via' => ['mail'],
 ```
 
-The package uses Laravel's notification system. You can add multiple channels:
-
-```php
-'notification_via' => ['mail', 'slack', 'database'],
-```
+The built-in notification supports the `mail` channel. Use a custom notification implementation if your application needs Slack, SMS, database, or another channel.
 
 ## Authentication Events
 

--- a/docs/03-usage.md
+++ b/docs/03-usage.md
@@ -192,7 +192,7 @@ $log->location['lon']        // Longitude
 
 If geolocation lookup fails, the location array will be empty.
 
-## Custom Notification Channels
+## Notification Channels
 
 Override the notification channels for a specific user:
 
@@ -203,15 +203,12 @@ class User extends Authenticatable
 
     public function notifyAuthenticationLogVia(): array
     {
-        // Send to mail and Slack for admin users
-        if ($this->isAdmin()) {
-            return ['mail', 'slack'];
-        }
-
         return ['mail'];
     }
 }
 ```
+
+The built-in notification supports `mail`. Use a custom notification implementation before returning other channels.
 
 ## Disabling Automatic Notifications
 

--- a/src/Notifications/AuthLogsNotification.php
+++ b/src/Notifications/AuthLogsNotification.php
@@ -9,6 +9,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
+use RuntimeException;
 
 final class AuthLogsNotification extends Notification implements ShouldQueue
 {
@@ -27,7 +28,20 @@ final class AuthLogsNotification extends Notification implements ShouldQueue
     public function via(mixed $notifiable): array
     {
 
-        return $notifiable->notifyAuthenticationLogVia(); // @phpstan-ignore-line
+        $channels = type($notifiable->notifyAuthenticationLogVia())->asArray(); // @phpstan-ignore-line
+        $resolvedChannels = [];
+
+        foreach ($channels as $channel) {
+            $channel = type($channel)->asString();
+
+            if ($channel !== 'mail') {
+                throw new RuntimeException('Laravel Auth Logs only supports the mail notification channel by default.');
+            }
+
+            $resolvedChannels[] = $channel;
+        }
+
+        return $resolvedChannels;
     }
 
     /**

--- a/tests/Unit/CoverageExtrasTest.php
+++ b/tests/Unit/CoverageExtrasTest.php
@@ -39,6 +39,21 @@ it('notification channels and toMail are returned', function (): void {
     expect(method_exists($mail, 'render'))->toBeTrue();
 });
 
+it('notification rejects unsupported channels', function (): void {
+
+    $notification = new AuthLogsNotification(new NewDevice('2025-01-01 00:00:00', '127.0.0.1', 'Nowhere', 'UA'));
+    $notifiable = new class
+    {
+        public function notifyAuthenticationLogVia(): array
+        {
+            return ['slack'];
+        }
+    };
+
+    expect(fn (): array => $notification->via($notifiable))
+        ->toThrow(\RuntimeException::class, 'Laravel Auth Logs only supports the mail notification channel by default.');
+});
+
 it('authentication log morph relation resolves authenticatable', function (): void {
 
     config()->set('auth-logs.db_connection', 'testing');


### PR DESCRIPTION
Problem: fixes #21. The config and docs suggested non-mail notification channels, but the built-in notification only implements mail delivery.

Root cause: AuthLogsNotification returned arbitrary configured channels without validating that it can render those channels.

Solution: normalize configured channels, reject unsupported channels with a clear RuntimeException, and update docs/config comments to state that built-in support is mail only.

Validation:
- vendor/bin/pest tests/Unit/CoverageExtrasTest.php --compact
- composer test

Risk/rollback: medium. Apps that configured unsupported channels now fail earlier with a clearer error instead of later in Laravel notification delivery. Revert the commit to restore passthrough behavior.