### PR TITLE
ci: fix Dependabot PR checks

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,8 @@ namespace Akira\LaravelAuthLogs\Tests;
 
 use Akira\Debugger\DebuggerServiceProvider;
 use Akira\LaravelAuthLogs\LaravelAuthLogsServiceProvider;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Config\Repository;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -15,6 +17,8 @@ abstract class TestCase extends Orchestra
 {
     protected function setUp(): void
     {
+
+        $this->resetAuthLogsConfiguration();
 
         parent::setUp();
 
@@ -27,7 +31,6 @@ abstract class TestCase extends Orchestra
     final public function getEnvironmentSetUp($app): void
     {
 
-        // Configure in-memory sqlite for tests
         config()->set('database.default', 'testing');
         config()->set('database.connections.testing', [
             'driver' => 'sqlite',
@@ -35,7 +38,6 @@ abstract class TestCase extends Orchestra
             'prefix' => '',
         ]);
 
-        // Minimal users table for morph relations in tests
         Schema::create('users', function (Blueprint $table): void {
 
             $table->id();
@@ -44,7 +46,6 @@ abstract class TestCase extends Orchestra
             $table->timestamps();
         });
 
-        // Authentication logs table used by the package model
         Schema::create('authentication_logs', function (Blueprint $table): void {
 
             $table->id();
@@ -67,5 +68,26 @@ abstract class TestCase extends Orchestra
             LaravelAuthLogsServiceProvider::class,
             DebuggerServiceProvider::class,
         ];
+    }
+
+    private function resetAuthLogsConfiguration(): void
+    {
+        $container = Container::getInstance();
+
+        if (! $container->bound('config')) {
+            return;
+        }
+
+        $configuration = $container->make('config');
+
+        if (! $configuration instanceof Repository) {
+            return;
+        }
+
+        if (is_array($configuration->get('auth-logs', []))) {
+            return;
+        }
+
+        $configuration->set('auth-logs', []);
     }
 }


### PR DESCRIPTION
## Summary
- pin dependabot/fetch-metadata to a full commit SHA so the auto-merge workflow passes the repository action policy
- reset stale non-array auth-logs config before Testbench boots each test app to avoid random-order mergeConfigFrom failures

## Validation
- actionlint .github/workflows/dependabot-auto-merge.yml
- composer test