### PR TITLE
ci: align Dependabot security update manifests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,13 +19,3 @@ updates:
     commit-message:
       prefix: "chore(deps)"
     open-pull-requests-limit: 10
-
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
-    commit-message:
-      prefix: "chore(deps)"
-    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Remove the stale npm Dependabot ecosystem entry now that Node release tooling and lockfiles are gone from 1.x.
- Keep GitHub Actions and Composer update coverage in place.
- Verified repository Dependabot security updates are enabled through the GitHub API.

## Validation
- composer test

Fixes #42