### PR TITLE
test: cover auth log event wiring

### DIFF
--- a/tests/Console/AuthLogsInstallCommandTest.php
+++ b/tests/Console/AuthLogsInstallCommandTest.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
 test('it can run the command', function (): void {
 
     $this->artisan('auth-logs:install')
@@ -33,8 +36,25 @@ test('it can run the command silently', function (): void {
         ->assertExitCode(0);
 });
 
-test('the migration stub supports rollback', function (): void {
+test('the migration stub can roll back the configured table', function (): void {
+    config()->set('auth-logs.table_name', 'authentication_logs_rollback_test');
 
+    Schema::dropIfExists('authentication_logs_rollback_test');
+
+    $migration = require __DIR__.'/../../database/migrations/create_laravel_auth_logs_table.php.stub';
+
+    expect($migration)->toBeInstanceOf(Migration::class);
+
+    $migration->up();
+
+    expect(Schema::hasTable('authentication_logs_rollback_test'))->toBeTrue();
+
+    $migration->down();
+
+    expect(Schema::hasTable('authentication_logs_rollback_test'))->toBeFalse();
+});
+
+test('the migration stub declares rollback support', function (): void {
     $stub = file_get_contents(__DIR__.'/../../database/migrations/create_laravel_auth_logs_table.php.stub');
 
     expect($stub)

--- a/tests/Unit/ListenersTest.php
+++ b/tests/Unit/ListenersTest.php
@@ -97,6 +97,24 @@ it('logout listener registers logout on the latest authentication log', function
         ->cleared_by_user->toBeTrue();
 });
 
+it('configured auth events are registered to their configured listeners', function (): void {
+    $configuredListeners = [
+        [(string) config('auth-logs.events.login'), (string) config('auth-logs.listeners.login')],
+        [(string) config('auth-logs.events.failed'), (string) config('auth-logs.listeners.failed')],
+        [(string) config('auth-logs.events.logout'), (string) config('auth-logs.listeners.logout')],
+        [(string) config('auth-logs.events.logout-other-devices'), (string) config('auth-logs.listeners.other_device_logout')],
+    ];
+
+    $raw = app('events')->getRawListeners();
+
+    foreach ($configuredListeners as [$event, $listener]) {
+        expect($event)->not->toBeEmpty()
+            ->and($listener)->not->toBeEmpty()
+            ->and($raw)->toHaveKey($event)
+            ->and($raw[$event])->toContain($listener);
+    }
+});
+
 it('logout event is registered to LogoutListener independently', function (): void {
     $raw = app('events')->getRawListeners();
 


### PR DESCRIPTION
## Summary
- Add coverage that every configured auth event is registered to its configured listener.
- Keep the existing independent logout and other-device logout checks.
- Execute the migration stub up and down against the configured table to cover rollback behavior.

## Validation
- composer test

Fixes #26