### PR TITLE
fix(logs): handle null auth log connection (#62)

### DIFF
--- a/src/AuthenticationLog.php
+++ b/src/AuthenticationLog.php
@@ -7,6 +7,7 @@ namespace Akira\LaravelAuthLogs;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use TypeError;
 
 /**
  * @property int $id
@@ -39,16 +40,22 @@ final class AuthenticationLog extends Model
         ];
 
     /**
-     * Get the database connection for the model.
+     * @throws TypeError
      */
     public function getConnectionName(): string
     {
 
-        return type(config('auth-logs.db_connection', parent::getConnectionName()))->asString(); // @codeCoverageIgnoreLine
+        $connection = config('auth-logs.db_connection', parent::getConnectionName());
+
+        if ($connection === null) {
+            return type(config('database.default'))->asString();
+        }
+
+        return type($connection)->asString();
     }
 
     /**
-     * Get the table associated with the model.
+     * @throws TypeError
      */
     public function getTable(): string
     {
@@ -57,8 +64,6 @@ final class AuthenticationLog extends Model
     }
 
     /**
-     * Get the authenticatable model associated with the log.
-     *
      * @return MorphTo<Model, $this>
      */
     public function authenticatable(): MorphTo
@@ -68,7 +73,7 @@ final class AuthenticationLog extends Model
     }
 
     /**
-     * Get the attributes that should be cast.
+     * @return array<string, string>
      */
     protected function casts(): array
     {

--- a/tests/Unit/ModelAndTemplatesTest.php
+++ b/tests/Unit/ModelAndTemplatesTest.php
@@ -17,6 +17,12 @@ it('authentication log casts, table and connection respond', function (): void {
         ->and($model->getTable())->toBe('authentication_logs');
 });
 
+it('uses the default database connection when auth logs connection is null', function (): void {
+    config()->set('auth-logs.db_connection');
+
+    expect(new AuthenticationLog()->getConnectionName())->toBe('testing');
+});
+
 it('templates render a mail message', function (): void {
     $user = new User(['email' => 't@example.test']);
 
@@ -31,4 +37,3 @@ it('templates render a mail message', function (): void {
         ->and(method_exists($mail2, 'render'))
         ->toBeTrue();
 });
-


### PR DESCRIPTION
Problem: Fixes #62. `auth-logs.db_connection` documented `null` as the default-connection path, but the model cast the value directly to string.

Root cause: `AuthenticationLog::getConnectionName()` passed the configured value through the type guard without handling `null`.

Solution: Fall back to `database.default` when the auth log connection is `null`, and cover that behavior with a Pest regression test.

Validation:
- `PATH="/Users/kid/Library/Application Support/Herd/bin:$PATH" XDEBUG_MODE=coverage vendor/bin/pest tests/Unit/ModelAndTemplatesTest.php --compact`
- `PATH="/Users/kid/Library/Application Support/Herd/bin:$PATH" XDEBUG_MODE=coverage composer test`

Risk/rollback: Low. The change only affects the documented null configuration path. Roll back by reverting the commit if an application depends on the previous exception behavior.
