### PR TITLE
fix(notifications): defer geolocation lookup (#63)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,10 +1,5 @@
 parameters:
   ignoreErrors:
-    - message: '#^Parameter \$template of class Akira\\LaravelAuthLogs\\Notifications\\AuthLogsNotification constructor expects Akira\\LaravelAuthLogs\\Contracts\\Template, mixed given\.$#'
-      identifier: argument.type
-      count: 1
-      path: src/Actions/SendNotification.php
-
     - message: '#^Property Akira\\LaravelAuthLogs\\Actions\\SendNotification\:\:\$authenticatable in isset\(\) is not nullable nor uninitialized\.$#'
       identifier: isset.initializedProperty
       count: 1

--- a/src/Actions/SendNotification.php
+++ b/src/Actions/SendNotification.php
@@ -15,7 +15,7 @@ final readonly class SendNotification
     use InteractsWithLogs;
 
     /**
-     * Send notification to the user.
+     * @phpstan-param string $template
      */
     public function __construct(
         private Authenticatable $authenticatable,
@@ -24,7 +24,7 @@ final readonly class SendNotification
     ) {}
 
     /**
-     * Create a new instance of the class.
+     * @phpstan-param string $template
      */
     public static function make(Authenticatable $authenticatable, string $template, AuthenticationLog $log): self
     {
@@ -33,20 +33,22 @@ final readonly class SendNotification
     }
 
     /**
-     * Send the notification.
+     * @throws RuntimeException
      */
     public function send(): void
     {
 
         $this->validateProperties();
 
-        $notification = $this->buildNotification();
-
-        $this->authenticatable->notify($notification); // @phpstan-ignore-line
+        /** @phpstan-ignore-next-line */
+        $this->authenticatable->notify(new AuthLogsNotification(
+            template: $this->template,
+            log     : $this->log,
+        ));
     }
 
     /**
-     * Validate the properties.
+     * @throws RuntimeException
      */
     private function validateProperties(): void
     {
@@ -62,24 +64,5 @@ final readonly class SendNotification
         if (! isset($this->log)) {
             throw new RuntimeException('Authentication log is required'); // @codeCoverageIgnoreLine
         }
-    }
-
-    /**
-     * Build the notification.
-     */
-    private function buildNotification(): AuthLogsNotification
-    {
-
-        return new AuthLogsNotification(
-            template: app(
-                abstract  : $this->template,
-                parameters: [
-                    'loginAt' => $this->getLoginAt(),
-                    'ipAddress' => $this->getIpAddress(),
-                    'location' => $this->getFullLocation(),
-                    'userAgent' => $this->getUserAgent(),
-                ],
-            ),
-        );
     }
 }

--- a/src/Notifications/AuthLogsNotification.php
+++ b/src/Notifications/AuthLogsNotification.php
@@ -4,25 +4,38 @@ declare(strict_types=1);
 
 namespace Akira\LaravelAuthLogs\Notifications;
 
+use Akira\LaravelAuthLogs\AuthenticationLog;
+use Akira\LaravelAuthLogs\Concerns\InteractsWithLogs;
 use Akira\LaravelAuthLogs\Contracts\Template;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
+use Illuminate\Queue\SerializesModels;
 use RuntimeException;
 
 final class AuthLogsNotification extends Notification implements ShouldQueue
 {
+    use InteractsWithLogs;
     use Queueable;
+    use SerializesModels;
+
+    private AuthenticationLog $log;
+
+    private bool $hasDeferredLog;
 
     /**
-     * Create a new notification instance.
+     * @phpstan-param Template|string $template
      */
-    public function __construct(private readonly Template $template) {}
+    public function __construct(
+        private Template|string $template,
+        ?AuthenticationLog $log = null,
+    ) {
+        $this->log = $log ?? new AuthenticationLog();
+        $this->hasDeferredLog = $log instanceof AuthenticationLog;
+    }
 
     /**
-     * Get the notification's delivery channels.
-     *
      * @return array<string>
      */
     public function via(mixed $notifiable): array
@@ -45,11 +58,42 @@ final class AuthLogsNotification extends Notification implements ShouldQueue
     }
 
     /**
-     * Get the mail representation of the notification.
+     * @throws RuntimeException
      */
     public function toMail(mixed $notifiable): MailMessage
     {
 
-        return $this->template->toMail($notifiable);
+        return $this->resolveTemplate()->toMail($notifiable);
+    }
+
+    /**
+     * @throws RuntimeException
+     */
+    private function resolveTemplate(): Template
+    {
+
+        if ($this->template instanceof Template) {
+            return $this->template;
+        }
+
+        if (! $this->hasDeferredLog) {
+            throw new RuntimeException('Authentication log is required to build deferred auth log notification template.');
+        }
+
+        $template = app(
+            abstract  : $this->template,
+            parameters: [
+                'loginAt' => $this->getLoginAt(),
+                'ipAddress' => $this->getIpAddress(),
+                'location' => $this->getFullLocation(),
+                'userAgent' => $this->getUserAgent(),
+            ],
+        );
+
+        if (! $template instanceof Template) {
+            throw new RuntimeException('Auth log notification template must implement the template contract.');
+        }
+
+        return $template;
     }
 }

--- a/tests/Unit/ActionsTest.php
+++ b/tests/Unit/ActionsTest.php
@@ -10,6 +10,7 @@ use Akira\LaravelAuthLogs\AuthenticationLog;
 use Akira\LaravelAuthLogs\Notifications\AuthLogsNotification;
 use Akira\LaravelAuthLogs\Templates\NewDevice;
 use Akira\LaravelAuthLogs\Tests\Fixtures\User;
+use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Support\Facades\Notification;
 
 it('creates an authentication log via action', function (): void {
@@ -106,6 +107,72 @@ it('uses a stored resolved location without another lookup', function (): void {
     expect($sender->getFullLocation())->toBe('Porto, Portugal');
 });
 
+it('defers location lookup until the notification mail is rendered', function (): void {
+    config()->set('auth-logs.db_connection', 'testing');
+    $fixtures = realpath(__DIR__.'/../Fixtures') ?: realpath(__DIR__.'/../fixtures');
+    config()->set('auth-logs.geolocation_api', 'file://'.$fixtures);
+
+    Notification::fake();
+
+    $user = User::create([
+        'email' => 'deferred-location@example.test',
+        'created_at' => now()->subMinutes(10),
+        'updated_at' => now()->subMinutes(10),
+    ]);
+
+    request()->server->set('REMOTE_ADDR', '1.1.1.1');
+    request()->headers->set('User-Agent', 'UA/deferred');
+    request()->merge(['location' => []]);
+
+    $log = CreateAuthenticationLog::for($user, true);
+
+    SendNotification::make($user, NewDevice::class, $log)->send();
+
+    expect($log->fresh()->location)->toBe([]);
+
+    Notification::assertSentTo(
+        $user,
+        AuthLogsNotification::class,
+        function (AuthLogsNotification $notification) use ($user, $log): bool {
+            expect($log->fresh()->location)->toBe([]);
+
+            $notification->toMail($user);
+
+            expect($log->fresh()->location)->toHaveKey('city', 'Emerald City');
+
+            return true;
+        },
+    );
+});
+
+it('requires an authentication log for deferred notification templates', function (): void {
+    $notification = new AuthLogsNotification(NewDevice::class);
+    $user = new User(['email' => 'missing-log@example.test']);
+
+    expect(fn (): MailMessage => $notification->toMail($user))
+        ->toThrow(RuntimeException::class, 'Authentication log is required to build deferred auth log notification template.');
+});
+
+it('rejects deferred notification templates without the template contract', function (): void {
+    config()->set('auth-logs.db_connection', 'testing');
+
+    $user = User::create([
+        'email' => 'invalid-template@example.test',
+        'created_at' => now()->subMinutes(10),
+        'updated_at' => now()->subMinutes(10),
+    ]);
+
+    request()->server->set('REMOTE_ADDR', '1.1.1.3');
+    request()->headers->set('User-Agent', 'UA/invalid-template');
+    request()->merge(['location' => []]);
+
+    $log = CreateAuthenticationLog::for($user, true);
+    $notification = new AuthLogsNotification(stdClass::class, $log);
+
+    expect(fn (): MailMessage => $notification->toMail($user))
+        ->toThrow(RuntimeException::class, 'Auth log notification template must implement the template contract.');
+});
+
 it('returns empty collection when geolocation fails', function (): void {
     config()->set('auth-logs.geolocation_api', 'file:///path/does/not/exist');
 
@@ -136,28 +203,28 @@ it('validates send notification properties', function (): void {
     request()->merge(['location' => []]);
     $log = CreateAuthenticationLog::for($user, false);
 
-    $ref = new \ReflectionClass(SendNotification::class);
+    $ref = new ReflectionClass(SendNotification::class);
     $ctor = $ref->getConstructor();
     $instance = $ref->newInstanceWithoutConstructor();
     $ctor->invoke($instance, $user, '', $log);
 
-    $method = new \ReflectionMethod($instance, 'send');
+    $method = new ReflectionMethod($instance, 'send');
 
     expect(fn (): mixed => $method->invoke($instance))
         ->toThrow(RuntimeException::class);
 
     $noAuth = $ref->newInstanceWithoutConstructor();
-    $sendNoAuth = new \ReflectionMethod($noAuth, 'send');
+    $sendNoAuth = new ReflectionMethod($noAuth, 'send');
     expect(fn (): mixed => $sendNoAuth->invoke($noAuth))
         ->toThrow(RuntimeException::class);
 
     $missingLog = $ref->newInstanceWithoutConstructor();
-    $pa = new \ReflectionProperty(SendNotification::class, 'authenticatable');
-    $pt = new \ReflectionProperty(SendNotification::class, 'template');
+    $pa = new ReflectionProperty(SendNotification::class, 'authenticatable');
+    $pt = new ReflectionProperty(SendNotification::class, 'template');
     $pa->setValue($missingLog, $user);
     $pt->setValue($missingLog, NewDevice::class);
 
-    $sendMissingLog = new \ReflectionMethod($missingLog, 'send');
+    $sendMissingLog = new ReflectionMethod($missingLog, 'send');
     expect(fn (): mixed => $sendMissingLog->invoke($missingLog))
         ->toThrow(RuntimeException::class);
 });


### PR DESCRIPTION
Problem: Fixes #63. Auth log notifications were queued, but their templates were built before dispatch, so geolocation lookup could run during login or failed-login request handling.

Root cause: `SendNotification::buildNotification()` called `getFullLocation()` while creating the notification instance.

Solution: Pass the template reference and authentication log into `AuthLogsNotification`, then resolve the template in `toMail()`. The existing template-object constructor path remains supported. Regression tests prove `send()` does not populate location until mail rendering.

Validation:
- `PATH="/Users/kid/Library/Application Support/Herd/bin:$PATH" XDEBUG_MODE=coverage vendor/bin/pest tests/Unit/ActionsTest.php --compact`
- `PATH="/Users/kid/Library/Application Support/Herd/bin:$PATH" XDEBUG_MODE=coverage composer test`

Risk/rollback: Moderate. This shifts template construction later in the queued notification lifecycle. Roll back by reverting the commit if an application depends on immediate template construction.
