### PR TITLE
fix(notifications): require mail templates (#64)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,10 +1,5 @@
 parameters:
   ignoreErrors:
-    - message: '#^Parameter \$template of class Akira\\LaravelAuthLogs\\Notifications\\AuthLogsNotification constructor expects Akira\\LaravelAuthLogs\\Contracts\\Template, mixed given\.$#'
-      identifier: argument.type
-      count: 1
-      path: src/Actions/SendNotification.php
-
     - message: '#^Property Akira\\LaravelAuthLogs\\Actions\\SendNotification\:\:\$authenticatable in isset\(\) is not nullable nor uninitialized\.$#'
       identifier: isset.initializedProperty
       count: 1

--- a/src/Actions/SendNotification.php
+++ b/src/Actions/SendNotification.php
@@ -40,10 +40,11 @@ final readonly class SendNotification
     {
 
         $this->validateProperties();
+        $template = $this->getTemplateClass();
 
         /** @phpstan-ignore-next-line */
         $this->authenticatable->notify(new AuthLogsNotification(
-            template: $this->template,
+            template: $template,
             log     : $this->log,
         ));
     }
@@ -65,9 +66,19 @@ final readonly class SendNotification
         if (! isset($this->log)) {
             throw new RuntimeException('Authentication log is required'); // @codeCoverageIgnoreLine
         }
+    }
 
+    /**
+     * @return class-string<ToMail>
+     *
+     * @throws RuntimeException
+     */
+    private function getTemplateClass(): string
+    {
         if (! is_a($this->template, ToMail::class, true)) {
             throw new RuntimeException('Auth log notification template must implement the mail template contract.');
         }
+
+        return $this->template;
     }
 }

--- a/src/Actions/SendNotification.php
+++ b/src/Actions/SendNotification.php
@@ -6,6 +6,7 @@ namespace Akira\LaravelAuthLogs\Actions;
 
 use Akira\LaravelAuthLogs\AuthenticationLog;
 use Akira\LaravelAuthLogs\Concerns\InteractsWithLogs;
+use Akira\LaravelAuthLogs\Contracts\ToMail;
 use Akira\LaravelAuthLogs\Notifications\AuthLogsNotification;
 use Illuminate\Contracts\Auth\Authenticatable;
 use RuntimeException;
@@ -15,7 +16,7 @@ final readonly class SendNotification
     use InteractsWithLogs;
 
     /**
-     * Send notification to the user.
+     * @phpstan-param string $template
      */
     public function __construct(
         private Authenticatable $authenticatable,
@@ -24,7 +25,7 @@ final readonly class SendNotification
     ) {}
 
     /**
-     * Create a new instance of the class.
+     * @phpstan-param string $template
      */
     public static function make(Authenticatable $authenticatable, string $template, AuthenticationLog $log): self
     {
@@ -33,7 +34,7 @@ final readonly class SendNotification
     }
 
     /**
-     * Send the notification.
+     * @throws RuntimeException
      */
     public function send(): void
     {
@@ -46,7 +47,7 @@ final readonly class SendNotification
     }
 
     /**
-     * Validate the properties.
+     * @throws RuntimeException
      */
     private function validateProperties(): void
     {
@@ -65,21 +66,25 @@ final readonly class SendNotification
     }
 
     /**
-     * Build the notification.
+     * @throws RuntimeException
      */
     private function buildNotification(): AuthLogsNotification
     {
 
-        return new AuthLogsNotification(
-            template: app(
-                abstract  : $this->template,
-                parameters: [
-                    'loginAt' => $this->getLoginAt(),
-                    'ipAddress' => $this->getIpAddress(),
-                    'location' => $this->getFullLocation(),
-                    'userAgent' => $this->getUserAgent(),
-                ],
-            ),
+        $template = app(
+            abstract  : $this->template,
+            parameters: [
+                'loginAt' => $this->getLoginAt(),
+                'ipAddress' => $this->getIpAddress(),
+                'location' => $this->getFullLocation(),
+                'userAgent' => $this->getUserAgent(),
+            ],
         );
+
+        if (! $template instanceof ToMail) {
+            throw new RuntimeException('Auth log notification template must implement the mail template contract.');
+        }
+
+        return new AuthLogsNotification(template: $template);
     }
 }

--- a/src/Contracts/Template.php
+++ b/src/Contracts/Template.php
@@ -4,16 +4,13 @@ declare(strict_types=1);
 
 namespace Akira\LaravelAuthLogs\Contracts;
 
-use Illuminate\Notifications\Messages\MailMessage;
-
-/**
- * @method MailMessage toMail(mixed $notifiable)
- *                                               /
- */
 interface Template
 {
     /**
-     * Get the mail representation of the notification.
+     * @phpstan-param string $loginAt
+     * @phpstan-param string $ipAddress
+     * @phpstan-param string $location
+     * @phpstan-param string $userAgent
      */
     public function __construct(
         string $loginAt,

--- a/src/LaravelAuthLogsServiceProvider.php
+++ b/src/LaravelAuthLogsServiceProvider.php
@@ -20,6 +20,18 @@ use Spatie\LaravelPackageTools\PackageServiceProvider;
 
 final class LaravelAuthLogsServiceProvider extends PackageServiceProvider
 {
+    /** @throws BindingResolutionException */
+    public function registeringPackage(): void
+    {
+        $config = $this->app->make('config');
+
+        if (is_array($config->get('auth-logs', []))) {
+            return;
+        }
+
+        $config->set('auth-logs', []);
+    }
+
     /**
      * Configure the package's behavior, such as its name, configuration, views,
      * migrations, and custom commands. Additionally, register event listeners

--- a/src/Notifications/AuthLogsNotification.php
+++ b/src/Notifications/AuthLogsNotification.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akira\LaravelAuthLogs\Notifications;
 
-use Akira\LaravelAuthLogs\Contracts\Template;
+use Akira\LaravelAuthLogs\Contracts\ToMail;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -16,13 +16,11 @@ final class AuthLogsNotification extends Notification implements ShouldQueue
     use Queueable;
 
     /**
-     * Create a new notification instance.
+     * @phpstan-param ToMail $template
      */
-    public function __construct(private readonly Template $template) {}
+    public function __construct(private readonly ToMail $template) {}
 
     /**
-     * Get the notification's delivery channels.
-     *
      * @return array<string>
      */
     public function via(mixed $notifiable): array
@@ -45,7 +43,7 @@ final class AuthLogsNotification extends Notification implements ShouldQueue
     }
 
     /**
-     * Get the mail representation of the notification.
+     * @phpstan-return MailMessage
      */
     public function toMail(mixed $notifiable): MailMessage
     {

--- a/tests/Unit/ActionsTest.php
+++ b/tests/Unit/ActionsTest.php
@@ -7,6 +7,7 @@ use Akira\LaravelAuthLogs\Actions\Device;
 use Akira\LaravelAuthLogs\Actions\GetLocation;
 use Akira\LaravelAuthLogs\Actions\SendNotification;
 use Akira\LaravelAuthLogs\AuthenticationLog;
+use Akira\LaravelAuthLogs\Contracts\Template;
 use Akira\LaravelAuthLogs\Notifications\AuthLogsNotification;
 use Akira\LaravelAuthLogs\Templates\NewDevice;
 use Akira\LaravelAuthLogs\Tests\Fixtures\User;
@@ -106,6 +107,34 @@ it('uses a stored resolved location without another lookup', function (): void {
     expect($sender->getFullLocation())->toBe('Porto, Portugal');
 });
 
+it('rejects notification templates that cannot render mail', function (): void {
+    config()->set('auth-logs.db_connection', 'testing');
+
+    $user = User::create([
+        'email' => 'template-contract@example.test',
+        'created_at' => now()->subMinutes(10),
+        'updated_at' => now()->subMinutes(10),
+    ]);
+
+    request()->server->set('REMOTE_ADDR', '1.1.1.3');
+    request()->headers->set('User-Agent', 'UA/template-contract');
+    request()->merge(['location' => []]);
+
+    $log = CreateAuthenticationLog::for($user, true);
+    $template = new readonly class('', '', '', '') implements Template
+    {
+        public function __construct(
+            string $loginAt,
+            string $ipAddress,
+            string $location,
+            string $userAgent,
+        ) {}
+    };
+
+    expect(fn (): mixed => SendNotification::make($user, $template::class, $log)->send())
+        ->toThrow(RuntimeException::class, 'Auth log notification template must implement the mail template contract.');
+});
+
 it('returns empty collection when geolocation fails', function (): void {
     config()->set('auth-logs.geolocation_api', 'file:///path/does/not/exist');
 
@@ -136,28 +165,28 @@ it('validates send notification properties', function (): void {
     request()->merge(['location' => []]);
     $log = CreateAuthenticationLog::for($user, false);
 
-    $ref = new \ReflectionClass(SendNotification::class);
+    $ref = new ReflectionClass(SendNotification::class);
     $ctor = $ref->getConstructor();
     $instance = $ref->newInstanceWithoutConstructor();
     $ctor->invoke($instance, $user, '', $log);
 
-    $method = new \ReflectionMethod($instance, 'send');
+    $method = new ReflectionMethod($instance, 'send');
 
     expect(fn (): mixed => $method->invoke($instance))
         ->toThrow(RuntimeException::class);
 
     $noAuth = $ref->newInstanceWithoutConstructor();
-    $sendNoAuth = new \ReflectionMethod($noAuth, 'send');
+    $sendNoAuth = new ReflectionMethod($noAuth, 'send');
     expect(fn (): mixed => $sendNoAuth->invoke($noAuth))
         ->toThrow(RuntimeException::class);
 
     $missingLog = $ref->newInstanceWithoutConstructor();
-    $pa = new \ReflectionProperty(SendNotification::class, 'authenticatable');
-    $pt = new \ReflectionProperty(SendNotification::class, 'template');
+    $pa = new ReflectionProperty(SendNotification::class, 'authenticatable');
+    $pt = new ReflectionProperty(SendNotification::class, 'template');
     $pa->setValue($missingLog, $user);
     $pt->setValue($missingLog, NewDevice::class);
 
-    $sendMissingLog = new \ReflectionMethod($missingLog, 'send');
+    $sendMissingLog = new ReflectionMethod($missingLog, 'send');
     expect(fn (): mixed => $sendMissingLog->invoke($missingLog))
         ->toThrow(RuntimeException::class);
 });

--- a/tests/Unit/CoverageExtrasTest.php
+++ b/tests/Unit/CoverageExtrasTest.php
@@ -9,6 +9,7 @@ use Akira\LaravelAuthLogs\AuthenticationLog;
 use Akira\LaravelAuthLogs\Facades\LaravelAuthLogs;
 use Akira\LaravelAuthLogs\Listeners\FailedLoginListener;
 use Akira\LaravelAuthLogs\Listeners\LogoutListener;
+use Akira\LaravelAuthLogs\LaravelAuthLogsServiceProvider;
 use Akira\LaravelAuthLogs\Notifications\AuthLogsNotification;
 use Akira\LaravelAuthLogs\Templates\NewDevice;
 use Akira\LaravelAuthLogs\Tests\Fixtures\User;
@@ -22,6 +23,16 @@ it('facade accessor returns underlying class', function (): void {
     $m = $ref->getMethod('getFacadeAccessor');
     $result = $m->invoke(null);
     expect($result)->toBe(Akira\LaravelAuthLogs\LaravelAuthLogs::class);
+});
+
+it('normalizes scalar auth logs configuration before package registration', function (): void {
+
+    config()->set('auth-logs', 1);
+
+    $provider = new LaravelAuthLogsServiceProvider($this->app);
+    $provider->registeringPackage();
+
+    expect(config('auth-logs'))->toBe([]);
 });
 
 it('logout listener handle executes', function (): void {


### PR DESCRIPTION
Problem: Fixes #64. `AuthLogsNotification` accepted the broad `Template` contract even though the built-in notification only renders mail.

Root cause: The base `Template` contract advertised `toMail()` through PHPDoc, and the notification constructor accepted that broad type.

Solution: Make `AuthLogsNotification` require `ToMail`, remove the misleading `Template` PHPDoc method, and validate resolved templates in `SendNotification` before notification dispatch.

Validation:
- `PATH="/Users/kid/Library/Application Support/Herd/bin:$PATH" XDEBUG_MODE=coverage vendor/bin/pest tests/Unit/ActionsTest.php tests/Unit/CoverageExtrasTest.php --compact`
- `PATH="/Users/kid/Library/Application Support/Herd/bin:$PATH" XDEBUG_MODE=coverage composer test`

Risk/rollback: Moderate. Manual construction of `AuthLogsNotification` now requires a mail-capable template. Roll back by reverting the commit if consumers need the old broad constructor type.
