### PR TITLE
chore: ignore node modules (#65)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Composer Related
 composer.lock
 /vendor
+/node_modules
 
 # Caches
 .phpunit.cache


### PR DESCRIPTION
Problem: Fixes #65. Local `node_modules/` installs appeared as untracked files and polluted developer status and search output.

Root cause: `/node_modules` was removed from `.gitignore` while the directory can still exist locally.

Solution: Restore `/node_modules` to `.gitignore` near the other local dependency artifacts.

Validation:
- `PATH="/Users/kid/Library/Application Support/Herd/bin:$PATH" XDEBUG_MODE=coverage composer test`

Risk/rollback: Low. This only affects local git ignore behavior. Roll back by reverting the commit if the repository intentionally wants `node_modules/` visible.
