### PR TITLE
docs: clarify other device logout behavior (#66)

### DIFF
--- a/docs/03-usage.md
+++ b/docs/03-usage.md
@@ -6,12 +6,13 @@ Once installed and configured, the package automatically tracks authentication a
 
 ### Automatic Logging
 
-After adding the `AuthLogs` trait to your User model, authentication events are logged automatically:
+After adding the `AuthLogs` trait to your User model, these authentication events are logged automatically:
 
 - **Login**: Successful authentication attempts
 - **Failed Login**: Failed authentication attempts with incorrect credentials
 - **Logout**: User-initiated logouts
-- **Other Device Logout**: When a user logs out of other devices
+
+The package also subscribes to `OtherDeviceLogout` as a customization hook. Its default listener does not write a log entry.
 
 ### Accessing Authentication Logs
 

--- a/docs/06-api-reference.md
+++ b/docs/06-api-reference.md
@@ -212,9 +212,9 @@ Handles logout events.
 
 ##### `handle()`
 ```php
-public function handle(): void
+public function handle(Logout $event): void
 ```
-Currently a placeholder for custom logout handling.
+Marks the latest authentication log as logged out when the authenticated model supports logout registration.
 
 ### `Akira\LaravelAuthLogs\Listeners\OtherDeviceLogoutListener`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -56,7 +56,8 @@ Subscribed events (configurable in `config/auth-logs.php`):
 Default behavior:
 - Login: Creates a successful log and, if the device is new and the user isn’t brand new, sends a “new device” notification
 - Failed: If a user instance exists, creates a failed log and sends a “failed login” notification
-- Logout / OtherDeviceLogout: Hooks exist for customization; default listeners are no-op
+- Logout: Updates the latest authentication log with `logout_at` and marks it as cleared by the user
+- OtherDeviceLogout: Hook exists for customization; the default listener is no-op
 
 Customize listeners in config:
 ```php
@@ -226,4 +227,3 @@ Logs not created on logout:
 
 Helper methods differ across versions:
 - Prefer using `authenticationLogs()` and `latestAuthentication()` queries
-


### PR DESCRIPTION
Problem: Fixes #66. The docs described OtherDeviceLogout as automatically tracked, while the default listener is a customization hook.

Root cause: Usage docs grouped Logout and OtherDeviceLogout together, and the API reference incorrectly described LogoutListener as a placeholder.

Solution: Clarify that login, failed login, and logout are logged automatically; document OtherDeviceLogout as a no-op customization hook; correct the LogoutListener API reference.

Validation:
- `PATH="/Users/kid/Library/Application Support/Herd/bin:$PATH" XDEBUG_MODE=coverage composer test`

Risk/rollback: Low. Documentation-only change. Roll back by reverting the commit if the docs need different product wording.
